### PR TITLE
Add more cutoff calculation methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifeq ($(MAKELEVEL),0)
 	export EXE_NAMES_FILE := $(abspath $(PARAMETERS_FOLDER)/exe_files_names.mk)
 	export NUMBER_POINTS_SMOOTH_FILE := $(abspath $(PARAMETERS_FOLDER)/nb_pts_smooth.mk)
 	export NUMBER_POINTS_BEGIN_END_FILE := $(abspath $(PARAMETERS_FOLDER)/nb_pts_smooth_end.mk)
-	export STRESS_THRESHOLD_FILE := $(abspath $(PARAMETERS_FOLDER)/stress_thresh.mk)
+	export PARAMS_DETECT_BEGIN_FILE := $(abspath $(PARAMETERS_FOLDER)/params_detect_begin.mk)
 	export MODULI_RANGES_FILE := $(abspath $(PARAMETERS_FOLDER)/moduli_ranges.mk)
 	export PEAK_THRESHOLD_FILE := $(abspath $(PARAMETERS_FOLDER)/peak_thresh.mk)
 endif
@@ -22,7 +22,7 @@ ifeq ($(MAKELEVEL),0)
 	include $(EXE_NAMES_FILE)
 	include $(NUMBER_POINTS_SMOOTH_FILE)
 	include $(NUMBER_POINTS_BEGIN_END_FILE)
-	include $(STRESS_THRESHOLD_FILE)
+	include $(PARAMS_DETECT_BEGIN_FILE)
 	include $(MODULI_RANGES_FILE)
 	include $(PEAK_THRESHOLD_FILE)
 endif
@@ -118,10 +118,10 @@ $(ULTIMATE_STRENGTH_FILE): $(ULTIMATE_STRENGTH_EXE_FILE) $(STRESS_STRAIN_FILES)
 .PHONY: begin
 begin: $(BEGIN_FILE) ## Detects the begin extension of the valid stress-strain data for each test, and saves it to a .csv file
 
-$(BEGIN_FILE): $(BEGIN_EXE_FILE) $(ULTIMATE_STRENGTH_FILE) $(STRESS_STRAIN_FILES) $(STRESS_THRESHOLD_FILE)
+$(BEGIN_FILE): $(BEGIN_EXE_FILE) $(ULTIMATE_STRENGTH_FILE) $(STRESS_STRAIN_FILES) $(PARAMS_DETECT_BEGIN_FILE)
 	@mkdir -p $(@D)
 	@echo "Writing $(abspath $@)"
-	@$(BEGIN_EXE) $(abspath $@) $(STRESS_THRESHOLD) $(abspath $(filter-out $< $(STRESS_THRESHOLD_FILE), $^))
+	@$(BEGIN_EXE) $(abspath $@) $(USE_SECOND_DERIVATIVE_BEGIN) $(BEGIN_STRESS_THRESHOLD) $(NB_POINTS_SMOOTH_BEGIN) $(SECOND_DERIVATIVE_THRESHOLD) $(abspath $(filter-out $< $(PARAMS_DETECT_BEGIN_FILE), $^))
 
 .PHONY: trim_begin
 trim_begin: $(BEGIN_TRIMMED_STRESS_STRAIN_FILES) ## Takes the stress-strain data as an input, discards the invalid beginning part, and saves only the valid part of it to a .csv file for each test

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ DATA_NAMES_FILE := $(abspath $(PARAMETERS_FOLDER)/data_files_names.mk)
 ifeq ($(MAKELEVEL),0)
 	export EXE_NAMES_FILE := $(abspath $(PARAMETERS_FOLDER)/exe_files_names.mk)
 	export NUMBER_POINTS_SMOOTH_FILE := $(abspath $(PARAMETERS_FOLDER)/nb_pts_smooth.mk)
-	export NUMBER_POINTS_BEGIN_END_FILE := $(abspath $(PARAMETERS_FOLDER)/nb_pts_smooth_end.mk)
 	export PARAMS_DETECT_BEGIN_FILE := $(abspath $(PARAMETERS_FOLDER)/params_detect_begin.mk)
+	export PARAMS_DETECT_BEGIN_END := $(abspath $(PARAMETERS_FOLDER)/params_detect_end.mk)
 	export MODULI_RANGES_FILE := $(abspath $(PARAMETERS_FOLDER)/moduli_ranges.mk)
 	export PEAK_THRESHOLD_FILE := $(abspath $(PARAMETERS_FOLDER)/peak_thresh.mk)
 endif
@@ -21,7 +21,7 @@ include $(DATA_NAMES_FILE)
 ifeq ($(MAKELEVEL),0)
 	include $(EXE_NAMES_FILE)
 	include $(NUMBER_POINTS_SMOOTH_FILE)
-	include $(NUMBER_POINTS_BEGIN_END_FILE)
+	include $(PARAMS_DETECT_BEGIN_END)
 	include $(PARAMS_DETECT_BEGIN_FILE)
 	include $(MODULI_RANGES_FILE)
 	include $(PEAK_THRESHOLD_FILE)
@@ -142,10 +142,10 @@ $(EXTENSIBILITY_FILE): $(EXTENSIBILITY_EXE_FILE) $(BEGIN_TRIMMED_STRESS_STRAIN_F
 .PHONY: end
 end: $(END_FILE) ## Detects the end extension of the valid stress-strain data for each test, and saves it to a .csv file
 
-$(END_FILE): $(END_EXE_FILE) $(ULTIMATE_STRENGTH_FILE) $(EXTENSIBILITY_FILE) $(NUMBER_POINTS_BEGIN_END_FILE) $(PEAK_THRESHOLD_FILE) $(BEGIN_TRIMMED_STRESS_STRAIN_FILES)
+$(END_FILE): $(END_EXE_FILE) $(ULTIMATE_STRENGTH_FILE) $(EXTENSIBILITY_FILE) $(PARAMS_DETECT_BEGIN_END) $(PEAK_THRESHOLD_FILE) $(BEGIN_TRIMMED_STRESS_STRAIN_FILES)
 	@mkdir -p $(@D)
 	@echo "Writing $(abspath $@)"
-	@$(END_EXE) $(abspath $@) $(NB_POINTS_SMOOTH_END) $(PEAK_THRESHOLD) $(PEAK_RANGE) $(ULTIMATE_STRENGTH_FILE) $(EXTENSIBILITY_FILE) $(abspath $(filter-out $< $(ULTIMATE_STRENGTH_FILE) $(EXTENSIBILITY_FILE) $(NUMBER_POINTS_BEGIN_END_FILE) $(PEAK_THRESHOLD_FILE), $^))
+	@$(END_EXE) $(abspath $@) $(USE_SECOND_DERIVATIVE_END) $(NB_POINTS_SMOOTH_END) $(PEAK_THRESHOLD) $(PEAK_RANGE) $(ULTIMATE_STRENGTH_FILE) $(EXTENSIBILITY_FILE) $(abspath $(filter-out $< $(ULTIMATE_STRENGTH_FILE) $(EXTENSIBILITY_FILE) $(PARAMS_DETECT_BEGIN_END) $(PEAK_THRESHOLD_FILE), $^))
 
 .PHONY: trim_end
 trim_end: $(TRIMMED_STRESS_STRAIN_FILES) ## Takes the begin-trimmed stress-strain data as an input, discards the invalid end part, and saves only the valid part of it to a .csv file for each test

--- a/parameters/nb_pts_smooth_end.mk
+++ b/parameters/nb_pts_smooth_end.mk
@@ -1,3 +1,0 @@
-# The number of points to use for the Savitzky–Golay filter applied when
-# determining the end extension of the valid data
-export NB_POINTS_SMOOTH_END := 3000

--- a/parameters/params_detect_begin.mk
+++ b/parameters/params_detect_begin.mk
@@ -1,0 +1,18 @@
+# If true, the second derivative method is used for determining the begin
+# extension of the valid data. Otherwise, the stress threshold method is used.
+export USE_SECOND_DERIVATIVE_BEGIN := true
+
+# The stress threshold used for determining the begin extension of the valid
+# data will be BEGIN_STRESS_THRESHOLD / 100 * (max_stress - min_stress), if
+# using the stress threshold method
+export BEGIN_STRESS_THRESHOLD := 2
+
+# The number of points to use for the Savitzky–Golay filter applied when
+# determining the begin extension of the valid data, if using the second
+# derivative method
+export NB_POINTS_SMOOTH_BEGIN := 3000
+# The second derivative threshold used for determining the begin extension of
+# the valid data will be
+# SECOND_DERIVATIVE_THRESHOLD / 100 * max_second_derivative, if
+# using the second derivative method
+export SECOND_DERIVATIVE_THRESHOLD := 10

--- a/parameters/params_detect_end.mk
+++ b/parameters/params_detect_end.mk
@@ -1,0 +1,8 @@
+# If true, the second derivative method is used for determining the end
+# extension of the valid data. Otherwise, the maximum of the first derivative
+# is used.
+export USE_SECOND_DERIVATIVE_END := true
+
+# The number of points to use for the Savitzky–Golay filter applied when
+# determining the end extension of the valid data
+export NB_POINTS_SMOOTH_END := 3000

--- a/parameters/peak_thresh.mk
+++ b/parameters/peak_thresh.mk
@@ -2,4 +2,4 @@
 # will be PEAK_THRESHOLD / 100 * (max_stress - min_stress)
 # The maximum width of the peak, as a number of samples, will be PEAK_RANGE
 export PEAK_THRESHOLD := 1
-export PEAK_RANGE := 1000
+export PEAK_RANGE := 10000

--- a/parameters/stress_thresh.mk
+++ b/parameters/stress_thresh.mk
@@ -1,3 +1,0 @@
-# The stress threshold used for determining the begin extension of the valid data
-# will be STRESS_THRESHOLD / 100 * (max_stress - min_stress)
-export STRESS_THRESHOLD := 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tensile_processing"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = ["matplotlib", "pandas", "numpy", "scipy"]
 requires-python = ">=3.12"
 

--- a/src/tensile_processing/plotting/begin_end_curve.py
+++ b/src/tensile_processing/plotting/begin_end_curve.py
@@ -52,6 +52,11 @@ if __name__ == '__main__':
   ends = pd.read_csv(end_file)
   end = float(ends[end_field][ends[identifier_field] == test_nr].iloc[0])
 
+  # The end cutoff is calculated in an already re-interpolated extension basis
+  # It needs to be multiplied by the beginning cutoff to obtain the end cutoff
+  # value in the original extension basis, which is needed for display
+  end *= begin
+
   # Dividing data into three categories
   before = data[data[extension_field] < begin]
   after = data[data[extension_field] > end]

--- a/src/tensile_processing/processing/begin.py
+++ b/src/tensile_processing/processing/begin.py
@@ -3,12 +3,14 @@
 """This script reads stress-strain data from source files, as well as ultimate
 strengths from another file. It then determines for each source file the
 minimum extension above which the stress-strain data is considered valid, based
-on a percentage of the ultimate strength. The minimum extensions are finally
-saved at the provided location."""
+either on a percentage of the ultimate strength, or on a threshold on the
+second derivative of the stress. The minimum extensions are finally saved at
+the provided location."""
 
 import argparse
 import pandas as pd
 from typing import Optional
+from scipy.signal import savgol_filter
 
 from ..tools.argparse_checkers import checker_is_csv, checker_valid_csv
 from ..tools.fields import identifier_field, begin_field, \
@@ -25,9 +27,26 @@ if __name__ == '__main__':
   parser.add_argument('destination_file', type=checker_is_csv, nargs=1,
                       help="Path to the .csv file where to store the begin "
                            "extension data.")
+  parser.add_argument('use_second_derivative', type=str, nargs=1,
+                      help="Boolean indicating whether to use the second "
+                           "derivative method for detecting the minimum "
+                           "extension. Otherwise, the stress threshold method "
+                           "is used.")
   parser.add_argument('stress_threshold', type=float, nargs=1,
                       help="The percentage of the total stress below which the"
-                           " data is not considered valid.")
+                           " data is not considered valid. Only used with the "
+                           "stress threshold method.")
+  parser.add_argument('nb_points_smooth', type=int, nargs=1,
+                      help="Number of points to use for running the "
+                           "Savitzky-Golay filter for smoothening the second "
+                           "derivative of the stress, if the second derivative"
+                           " method is used. Only used with the second "
+                           "derivative method.")
+  parser.add_argument('second_derivative_threshold', type=float, nargs=1,
+                      help="The percentage of the maximum second derivative "
+                           "value below which the data is not considered "
+                           "valid. Only used with the second derivative "
+                           "method.")
   parser.add_argument('ultimate_strength_file', type=checker_valid_csv,
                       nargs=1, help="Path to the .csv file containing the "
                                     "ultimate strength.")
@@ -38,6 +57,9 @@ if __name__ == '__main__':
 
   # Getting the arguments from the parser
   destination = args.destination_file[0]
+  use_second_dev = True if args.use_second_derivative[0] == 'true' else False
+  nb_points_smooth = args.nb_points_smooth[0]
+  sec_dev_thresh = args.second_derivative_threshold[0] / 100
   source_files = args.source_files
   threshold = args.stress_threshold[0] / 100
   ultimate_strength_file = args.ultimate_strength_file[0]
@@ -58,9 +80,23 @@ if __name__ == '__main__':
     test_nr = get_nr(path)
     data = pd.read_csv(path)
 
-    # Determining the beginning point of the valid data
-    begin = data[extension_field][data[stress_field] >
-                                  threshold * max_stress].min()
+    # Determining the beginning point of the valid data based on the value of
+    # the second derivative
+    if use_second_dev:
+      ext_max = data[extension_field].where(
+        data[stress_field] == max_stress).min()
+      filtered_stress = savgol_filter(
+        data[stress_field].values, nb_points_smooth, 3,
+        deriv=2)[data[extension_field] <= ext_max]
+      filtered_ext = data[extension_field][data[extension_field] <= ext_max]
+      begin = filtered_ext[filtered_stress >
+                           sec_dev_thresh * filtered_stress.max()].min()
+
+    # Determining the beginning point of the valid data based on a stress
+    # threshold
+    else:
+      begin = data[extension_field][data[stress_field] >
+                                    threshold * max_stress].min()
 
     # Adding the values to the dataframe to save
     if to_write is None:

--- a/src/tensile_processing/processing/stress_strain.py
+++ b/src/tensile_processing/processing/stress_strain.py
@@ -11,7 +11,7 @@ import pandas as pd
 from ..tools.argparse_checkers import checker_is_csv, checker_valid_csv
 from ..tools.fields import identifier_field, initial_length_field, \
   height_offset_field, height_field, width_offset_field, width_field, \
-  extension_field, stress_field, time_field, position_field
+  extension_field, stress_field, time_field, position_field, effort_field
 from ..tools.get_nr import get_nr
 
 if __name__ == '__main__':
@@ -75,7 +75,8 @@ if __name__ == '__main__':
     width = float(notes[width_field].iloc[0])
 
   # Calculating the stress from the effort and the section
-  stress = effort.values / [1, width / 1000 * height / 1000]
+  stress = effort[[time_field,
+                   effort_field]].values / [1, width / 1000 * height / 1000]
   stress[:, 1] -= np.mean(stress[:200, 1])
   stress[:, 1] /= 1000
 


### PR DESCRIPTION
This PR introduces two alternative ways to compute the begin and end cutoff extensions for determining the valid data range for Yeoh interpolation. 

The begin cutoff extension was previously determined using a stress threshold calculated as a percentage of the total stress range, it can now also be determined based on the value of the second derivative of the stress. This second method gives better results in cases where the stress-strain curve is growing slowly in the beginning instead of being almost constant. 

Similarly, the end cutoff value was determined as the first cancellation point of the second derivative, it can now also be determined as the maximum of the first derivative. The first method gives better results for very smooth and regular curves, the second allows for a degree of tolerance in case the curve is a bit wavy.

The methods to use to determine the two thresholds can be selected by adjusting parameters in the configuration `*.mk` files.

Additionally, a bug preventing the correct generation of the begin-end plots was fixed, as well as another one occurring when the time and effort columns weren't in the expected order in the source `.csv` files.