### PR TITLE
Improve detection using second derivative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ begin: $(BEGIN_FILE) ## Detects the begin extension of the valid stress-strain d
 $(BEGIN_FILE): $(BEGIN_EXE_FILE) $(END_TRIMMED_STRESS_STRAIN_FILES) $(PARAMS_DETECT_BEGIN_FILE) $(PEAK_THRESHOLD_FILE)
 	@mkdir -p $(@D)
 	@echo "Writing $(abspath $@)"
-	@$(BEGIN_EXE) $(abspath $@) $(USE_SECOND_DERIVATIVE_BEGIN) $(BEGIN_STRESS_THRESHOLD) $(NB_POINTS_SMOOTH_BEGIN) $(SECOND_DERIVATIVE_THRESHOLD) $(PEAK_THRESHOLD) $(PEAK_RANGE) $(abspath $(filter-out $< $(PARAMS_DETECT_BEGIN_FILE) $(PEAK_THRESHOLD_FILE), $^))
+	@$(BEGIN_EXE) $(abspath $@) $(USE_SECOND_DERIVATIVE_BEGIN) $(BEGIN_STRESS_THRESHOLD) $(SECOND_DERIVATIVE_THRESHOLD) $(PEAK_THRESHOLD) $(PEAK_RANGE) $(abspath $(filter-out $< $(PARAMS_DETECT_BEGIN_FILE) $(PEAK_THRESHOLD_FILE), $^))
 
 .PHONY: trim_begin
 trim_begin: $(TRIMMED_STRESS_STRAIN_FILES) ## Takes the end-trimmed stress-strain data as an input, discards the invalid beginning part, and saves only the valid part of it to a .csv file for each test

--- a/parameters/params_detect_begin.mk
+++ b/parameters/params_detect_begin.mk
@@ -11,4 +11,4 @@ export BEGIN_STRESS_THRESHOLD := 2
 # the valid data will be
 # SECOND_DERIVATIVE_THRESHOLD / 100 * max_second_derivative, if
 # using the second derivative method
-export SECOND_DERIVATIVE_THRESHOLD := 15
+export SECOND_DERIVATIVE_THRESHOLD := 30

--- a/parameters/params_detect_begin.mk
+++ b/parameters/params_detect_begin.mk
@@ -7,10 +7,6 @@ export USE_SECOND_DERIVATIVE_BEGIN := true
 # using the stress threshold method
 export BEGIN_STRESS_THRESHOLD := 2
 
-# The number of points to use for the Savitzky–Golay filter applied when
-# determining the begin extension of the valid data, if using the second
-# derivative method
-export NB_POINTS_SMOOTH_BEGIN := 2000
 # The second derivative threshold used for determining the begin extension of
 # the valid data will be
 # SECOND_DERIVATIVE_THRESHOLD / 100 * max_second_derivative, if

--- a/parameters/params_detect_end.mk
+++ b/parameters/params_detect_end.mk
@@ -4,5 +4,6 @@
 export USE_SECOND_DERIVATIVE_END := true
 
 # The number of points to use for the Savitzky–Golay filter applied when
-# determining the end extension of the valid data
+# determining the end extension of the valid data, if the first derivative is
+# used
 export NB_POINTS_SMOOTH_END := 2000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tensile_processing"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = ["matplotlib", "pandas", "numpy", "scipy"]
 requires-python = ">=3.12"
 

--- a/src/tensile_processing/processing/begin.py
+++ b/src/tensile_processing/processing/begin.py
@@ -108,6 +108,7 @@ if __name__ == '__main__':
       # second derivative
       data = data[data[stress_field] <
                   data[stress_field].min() + 0.15 * stress_amp]
+      min_ext = data[extension_field].min()
 
       if nb_points_smooth > len(data):
         warn(f"Reduced the number of points from {nb_points_smooth} to "
@@ -123,11 +124,14 @@ if __name__ == '__main__':
 
       # Cutting at the last value below threshold, so that everything after it
       # is above
-      mask = sec_dev < sec_dev_thresh * sec_dev.max()
-      if mask.any():
-        begin = data[extension_field][mask].max()
+      if sec_dev.any():
+        mask = sec_dev < sec_dev_thresh * sec_dev.max()
+        if mask.any():
+          begin = data[extension_field][mask].max()
+        else:
+          begin = data[extension_field].min()
       else:
-        begin = data[extension_field].min()
+        begin = min_ext
 
     # Determining the beginning point of the valid data based on a stress
     # threshold

--- a/src/tensile_processing/processing/begin.py
+++ b/src/tensile_processing/processing/begin.py
@@ -11,7 +11,6 @@ import argparse
 import pandas as pd
 from typing import Optional
 from scipy.signal import savgol_filter, find_peaks
-from warnings import warn
 import numpy as np
 
 from ..tools.argparse_checkers import checker_is_csv, checker_valid_csv
@@ -38,12 +37,6 @@ if __name__ == '__main__':
                       help="The percentage of the total stress below which the"
                            " data is not considered valid. Only used with the "
                            "stress threshold method.")
-  parser.add_argument('nb_points_smooth', type=int, nargs=1,
-                      help="Number of points to use for running the "
-                           "Savitzky-Golay filter for smoothening the second "
-                           "derivative of the stress, if the second derivative"
-                           " method is used. Only used with the second "
-                           "derivative method.")
   parser.add_argument('second_derivative_threshold', type=float, nargs=1,
                       help="The percentage of the maximum second derivative "
                            "value below which the data is not considered "
@@ -64,7 +57,6 @@ if __name__ == '__main__':
   # Getting the arguments from the parser
   destination = args.destination_file[0]
   use_second_dev = True if args.use_second_derivative[0] == 'true' else False
-  nb_points_smooth = args.nb_points_smooth[0]
   sec_dev_thresh = args.second_derivative_threshold[0] / 100
   source_files = args.source_files
   stress_threshold = args.stress_threshold[0] / 100

--- a/src/tensile_processing/processing/begin.py
+++ b/src/tensile_processing/processing/begin.py
@@ -110,13 +110,10 @@ if __name__ == '__main__':
                   data[stress_field].min() + 0.15 * stress_amp]
       min_ext = data[extension_field].min()
 
-      if nb_points_smooth > len(data):
-        warn(f"Reduced the number of points from {nb_points_smooth} to "
-             f"{int(len(data) / 2)} !", RuntimeWarning)
-        nb_points_smooth = int(len(data) / 2)
-
-      sec_dev = savgol_filter(data[stress_field].values, nb_points_smooth, 3,
-                              deriv=2)
+      # Extreme curve smoothening before computing the second derivative
+      smooth = savgol_filter(data[stress_field].values,
+                             len(data[stress_field]) // 2, 3, deriv=0)
+      sec_dev = savgol_filter(smooth, len(smooth) // 2, 3, deriv=2)
 
       # Only the part of the second derivative until the maximum is of interest
       data = data.iloc[:sec_dev.argmax()]

--- a/src/tensile_processing/processing/end_fit.py
+++ b/src/tensile_processing/processing/end_fit.py
@@ -100,11 +100,13 @@ if __name__ == '__main__':
 
     # Retrieving the first point where the second derivative cancels
     if use_second_dev:
+      # Extreme curve smoothening before computing the second derivative
+      smooth = savgol_filter(data[stress_field].values,
+                             len(data[stress_field]) // 2, 3, deriv=0)
       # The maximum extension is determined as the first cancellation point of
       # the second derivative of the stress
-      filtered = savgol_filter(data[stress_field].values, nb_points_smooth, 3,
-                               deriv=2)
-      cancel = np.diff(np.sign(filtered))
+      sec_dev = savgol_filter(smooth, len(smooth) // 2, 3, deriv=2)
+      cancel = np.diff(np.sign(sec_dev))
       if np.any(cancel < 0):
         end = data[extension_field].values[np.min(np.where(cancel < 0))]
       else:


### PR DESCRIPTION
A begin and end extension cutoff detection using the second derivative of the stress was already implemented. However, its performance was still poor and many inaccuracies were present.

This PR introduces improvements to the detection with the second derivative, with a better curve smoothening and a more accurate detection window. It also slightly modifies the Makefile and the configuration files accordingly.